### PR TITLE
Release/v2.0.1

### DIFF
--- a/src/commands/Smite/CCG/Exchange.ts
+++ b/src/commands/Smite/CCG/Exchange.ts
@@ -100,11 +100,14 @@ export class Exchange extends NoxCommand {
                 })
             } else if (interaction.customId === selectButton.customId) {
                 skinName1 = interaction.message.embeds[0].title;
+                godName1 = interaction.message.embeds[0].author.name;
                 await embedMessage1.delete();
                 collector1.stop();
             }
         });
 
+        let godName1 = '';
+        let godName2 = '';
         collector1.on('end', async collected => {
             if (skinName1 === '') {
                 message.reply('You did not select a card. The exchange is canceled.');
@@ -160,8 +163,9 @@ export class Exchange extends NoxCommand {
                         })
                     } else if (interaction.customId === selectButton.customId) {
                         skinName2 = interaction.message.embeds[0].title;
+                        godName2 = interaction.message.embeds[0].author.name;
                         await embedMessage2.delete();
-                        await message.channel.send(`An exchange was started between ${author}'s **${skinName1}** and ${user}'s **${skinName2}**.\nType \`${this.container.client.options.defaultPrefix}accept\` to agree to the exchange, or \`${this.container.client.options.defaultPrefix}deny\` otherwise.`);
+                        await message.channel.send(`An exchange was started between ${author}'s **${skinName1} ${godName1}** and ${user}'s **${skinName2} ${godName2}**.\nType \`${this.container.client.options.defaultPrefix}accept\` to agree to the exchange, or \`${this.container.client.options.defaultPrefix}deny\` otherwise.`);
                         collector2.stop();
                     }
                 });
@@ -184,21 +188,17 @@ export class Exchange extends NoxCommand {
                                 collector3.stop();
                             } else if (m.content.startsWith(`${prefix}accept`)) {
                                 let skinId1 = 0;
-                                let godName1 = '';
                                 for (let i = 0; i < skins1.length; i++) {
                                     if (skins1[i].name === skinName1) {
                                         skinId1 = skins1[i].id;
-                                        godName1 = skins1[i].god.name;
                                         break;
                                     }
                                 }
 
                                 let skinId2 = 0;
-                                let godName2 = '';
                                 for (let i = 0; i < skins2.length; i++) {
                                     if (skins2[i].name === skinName2) {
                                         skinId2 = skins2[i].id;
-                                        godName2 = skins2[i].god.name;
                                         break;
                                     }
                                 }

--- a/src/commands/Smite/CCG/Fight.ts
+++ b/src/commands/Smite/CCG/Fight.ts
@@ -500,6 +500,6 @@ export class Fight extends NoxCommand {
         });
 
         await disconnectSkin(skinId, loserId);
-        return await connectSkin(skinId, winnerId);
+        return await connectSkin(skinId, winnerId, false);
     }
 }

--- a/src/commands/Smite/CCG/GodSkins.ts
+++ b/src/commands/Smite/CCG/GodSkins.ts
@@ -37,10 +37,14 @@ export class GodSkins extends NoxCommand {
 
         let skins = await getSkinsByGodName(godName);
 
+        let currentIndex = 0
+
+        selectButton.disabled = this.isSkinInWishlist(skins[currentIndex].name, await getSkinWishlist(player.id));
+
         let uniqueSkin = skins.length <= 1;
         const embedMessage1 = await message.reply({
             content: `Here are the cards for ${godName}.`,
-            embeds: [await this.generateGodSkinEmbed(skins, 0, player.id)],
+            embeds: [await this.generateGodSkinEmbed(skins, currentIndex, player.id)],
             components: [
                 new MessageActionRow({
                     components: uniqueSkin ? [...([selectButton])] : [...([backButton]), ...([selectButton]), ...([forwardButton])]
@@ -51,8 +55,6 @@ export class GodSkins extends NoxCommand {
         const collector = embedMessage1.createMessageComponentCollector({
             filter: ({ user }) => user.id === author.id
         })
-
-        let currentIndex = 0
         collector.on('collect', async interaction => {
             if (interaction.customId === backButton.customId || interaction.customId === forwardButton.customId) {
                 // Increase/decrease index

--- a/src/commands/Smite/CCG/GodSkins.ts
+++ b/src/commands/Smite/CCG/GodSkins.ts
@@ -117,7 +117,7 @@ export class GodSkins extends NoxCommand {
     protected async generateGodSkinEmbed(skins, index, playerId: number) {
         const embed = generateSkinEmbed(skins, index);
 
-        const owner = await getSkinOwner(skins[index].id, playerId);
+        const owner = await getSkinOwner(skins[index].id);
         if (owner !== null) {
             const user = await this.container.client.users.fetch(owner.player.user.id);
             if (user === null) {

--- a/src/commands/Smite/CCG/Player.ts
+++ b/src/commands/Smite/CCG/Player.ts
@@ -74,7 +74,7 @@ export class Player extends NoxCommand {
             fightDescription += `Current Losing Streak: \`${player.losingStreak}\`\n`;
         }
         if (player.winningStreak > 0) {
-            fightDescription += `Current Winning Streak: \`${player.losingStreak}\`\n`;
+            fightDescription += `Current Winning Streak: \`${player.winningStreak}\`\n`;
         }
 
         embed.addField('Fights', fightDescription, true);

--- a/src/commands/Smite/CCG/Wishlist.ts
+++ b/src/commands/Smite/CCG/Wishlist.ts
@@ -146,7 +146,7 @@ export class Wishlist extends NoxCommand {
     protected async generateGodSkinEmbed(skins, index, playerId: number) {
         const embed = generateSkinEmbed(skins, index);
 
-        const owner = await getSkinOwner(skins[index].id, playerId);
+        const owner = await getSkinOwner(skins[index].id);
         if (owner !== null) {
             const user = await this.container.client.users.fetch(owner.player.user.id);
             if (user === null) {

--- a/src/lib/database/utils/SkinsUtils.ts
+++ b/src/lib/database/utils/SkinsUtils.ts
@@ -335,12 +335,11 @@ export async function addSkinToWishlist(playerId: number, skinId: number) {
     });
 }
 
-export async function getSkinOwner(skinId: number, playerId: number) {
-    return await container.prisma.playersSkins.findUnique({
+export async function getSkinOwner(skinId: number) {
+    return await container.prisma.playersSkins.findFirst({
         where: {
-            playerId_skinId: {
-                playerId: playerId,
-                skinId: skinId
+            skin: {
+                id: skinId
             }
         },
         include: {

--- a/src/lib/database/utils/SkinsUtils.ts
+++ b/src/lib/database/utils/SkinsUtils.ts
@@ -399,12 +399,24 @@ export async function addWin(skinId: number, playerId: number) {
             },
             win: {
                 increment: 1
-            }
+            },
+            losingStreak: 0
         },
         where: {
             id: playerId
         }
     });
+
+    if (player.winningStreak > player.highestWinningStreak) {
+        await container.prisma.players.update({
+            data: {
+                highestWinningStreak: player.winningStreak
+            },
+            where: {
+                id: playerId
+            }
+        });
+    }
 
     return playersSkin;
 }
@@ -455,7 +467,8 @@ export async function addLoss(skinId: number, playerId: number) {
             },
             loss: {
                 increment: 1
-            }
+            },
+            winningStreak: 0
         },
         where: {
             id: playerId


### PR DESCRIPTION
### Bug fixes

- Fixed an issue with claim cooldown being reset after winning an "All-in" fight.
- Fixed an issue where the "Wish" button of the first skin in a god's skins list would always show up as "enabled", despite the user having the skin in their wishlist already.
- Fixed an issue with streaks not showing up properly when looking at a player's statistics.
- Fixed an issue where the skin owner would not be displayed when browsing skins with `team` or `wishlist` commands.

### QOL

- Added the god's names when starting an exchange with a player.