### PR TITLE
Release/v3.0.4

### DIFF
--- a/src/commands/Smite/CCG/Fight.ts
+++ b/src/commands/Smite/CCG/Fight.ts
@@ -4,7 +4,7 @@ import { addLoss, addWin, connectSkin, disconnectSkin, exhaustSkin, getSkinsByPl
 import { PlayerNotLoadedError } from '@lib/structures/errors/PlayerNotLoadedError';
 import { NoxCommand } from '@lib/structures/NoxCommand';
 import { NoxCommandOptions } from '@lib/structures/NoxCommandOptions';
-import { getBackButton, getButton, getForwardButton, getSelectButton } from '@lib/utils/PaginationUtils';
+import { getBackButton, getButton, getEndButton, getForwardButton, getSelectButton, getStartButton } from '@lib/utils/PaginationUtils';
 import { generateSkinEmbed } from '@lib/utils/smite/SkinsPaginationUtils';
 import { getRandomIntInclusive } from '@lib/utils/Utils';
 import { ApplyOptions } from '@sapphire/decorators';
@@ -47,6 +47,8 @@ export class Fight extends NoxCommand {
         const forwardButton = getForwardButton();
         const fightButton = getSelectButton('Fight', 'SUCCESS', '⚔');
         const allInButton = getButton('allin', 'All In', 'DANGER', '💀');
+        const endButton = getEndButton();
+        const startButton = getStartButton();
 
         const skins1 = await getSkinsByPlayer(authorPlayer.id);
         if (!skins1 || skins1.length === 0) {
@@ -56,8 +58,8 @@ export class Fight extends NoxCommand {
             });
         }
         let allExhausted = true;
-        for (let i in skins1) {
-            if (!skins1[i].playersSkins[0].isExhausted) {
+        for (let skin of skins1) {
+            if (!skin.playersSkins[0].isExhausted) {
                 allExhausted = false;
                 break;
             }
@@ -77,8 +79,8 @@ export class Fight extends NoxCommand {
             });
         }
         allExhausted = true;
-        for (let i in skins2) {
-            if (!skins2[i].playersSkins[0].isExhausted) {
+        for (let skin of skins2) {
+            if (!skin.playersSkins[0].isExhausted) {
                 allExhausted = false;
                 break;
             }
@@ -103,9 +105,14 @@ export class Fight extends NoxCommand {
 
         // Send the embed with the first skin
         let currentIndex = 0;
-        skins1.length <= 1
-            ? forwardButton.setDisabled(true)
-            : forwardButton.setDisabled(false);
+        if (skins1.length <= 1) {
+            forwardButton.setDisabled(true);
+            endButton.setDisabled(true);
+        } else {
+            forwardButton.setDisabled(false);
+            endButton.setDisabled(false);
+        }
+
         fightButton.disabled = skins1[currentIndex].playersSkins[0].isExhausted;
         allInButton.disabled = skins1[currentIndex].playersSkins[0].isExhausted;
 
@@ -114,7 +121,7 @@ export class Fight extends NoxCommand {
             embeds: [await this.generateEmbed(skins1, currentIndex, guildId)],
             components: [
                 new MessageActionRow({
-                    components: [...([backButton]), ...([forwardButton])]
+                    components: [...([startButton]), ...([backButton]), ...([forwardButton]), ...([endButton])]
                 }),
                 new MessageActionRow({
                     components: [...([fightButton]), ...([allInButton])]
@@ -142,9 +149,17 @@ export class Fight extends NoxCommand {
         let rarity2 = '';
         let god1, god2, skin1, skin2;
         collector1.on('collect', async interaction => {
-            if (interaction.customId === backButton.customId || interaction.customId === forwardButton.customId) {
+            if (
+                interaction.customId === startButton.customId
+                || interaction.customId === backButton.customId
+                || interaction.customId === forwardButton.customId
+                || interaction.customId === endButton.customId
+            ) {
                 // Increase/decrease index
                 switch (interaction.customId) {
+                    case startButton.customId:
+                        currentIndex = 0;
+                        break;
                     case backButton.customId:
                         if (currentIndex > 0) {
                             currentIndex -= 1;
@@ -155,11 +170,16 @@ export class Fight extends NoxCommand {
                             currentIndex += 1;
                         }
                         break;
+                    case endButton.customId:
+                        currentIndex = skins1.length - 1;
+                        break;
                 }
 
                 // Disable the buttons if they cannot be used
-                forwardButton.disabled = currentIndex === skins1.length - 1;
+                startButton.disabled = currentIndex === 0;
                 backButton.disabled = currentIndex === 0;
+                forwardButton.disabled = currentIndex === skins1.length - 1;
+                endButton.disabled = currentIndex >= skins1.length - 1;
                 fightButton.disabled = skins1[currentIndex].playersSkins[0].isExhausted;
                 allInButton.disabled = skins1[currentIndex].playersSkins[0].isExhausted;
 
@@ -168,7 +188,7 @@ export class Fight extends NoxCommand {
                     embeds: [await this.generateEmbed(skins1, currentIndex, guildId)],
                     components: [
                         new MessageActionRow({
-                            components: [...([backButton]), ...([forwardButton])]
+                            components: [...([startButton]), ...([backButton]), ...([forwardButton]), ...([endButton])]
                         }),
                         new MessageActionRow({
                             components: [...([fightButton]), ...([allInButton])]
@@ -232,10 +252,16 @@ export class Fight extends NoxCommand {
                         this._channelIds.splice(runningInIndex, 1);
                     } else {
                         currentIndex = 0
+                        startButton.setDisabled(true);
                         backButton.setDisabled(true);
-                        skins2.length <= 1
-                            ? forwardButton.setDisabled(true)
-                            : forwardButton.setDisabled(false);
+                        if (skins2.length <= 1) {
+                            forwardButton.setDisabled(true);
+                            endButton.setDisabled(true);
+                        } else {
+                            forwardButton.setDisabled(false);
+                            endButton.setDisabled(false);
+                        }
+
                         fightButton.disabled = skins2[currentIndex].playersSkins[0].isExhausted;
                         allInButton.disabled = skins2[currentIndex].playersSkins[0].isExhausted;
 
@@ -248,7 +274,7 @@ export class Fight extends NoxCommand {
                             embeds: [await this.generateEmbed(skins2, currentIndex, guildId)],
                             components: [
                                 new MessageActionRow({
-                                    components: [...([backButton]), ...([forwardButton])]
+                                    components: [...([startButton]), ...([backButton]), ...([forwardButton]), ...([endButton])]
                                 }),
                                 new MessageActionRow({
                                     components: fightComponents
@@ -263,9 +289,17 @@ export class Fight extends NoxCommand {
                             time: 120000
                         });
                         collector3.on('collect', async interaction => {
-                            if (interaction.customId === backButton.customId || interaction.customId === forwardButton.customId) {
+                            if (
+                                interaction.customId === startButton.customId
+                                || interaction.customId === backButton.customId
+                                || interaction.customId === forwardButton.customId
+                                || interaction.customId === endButton.customId
+                            ) {
                                 // Increase/decrease index
                                 switch (interaction.customId) {
+                                    case startButton.customId:
+                                        currentIndex = 0;
+                                        break;
                                     case backButton.customId:
                                         if (currentIndex > 0) {
                                             currentIndex -= 1;
@@ -276,11 +310,16 @@ export class Fight extends NoxCommand {
                                             currentIndex += 1;
                                         }
                                         break;
+                                    case endButton.customId:
+                                        currentIndex = skins2.length - 1;
+                                        break;
                                 }
 
                                 // Disable the buttons if they cannot be used
-                                forwardButton.disabled = currentIndex === skins2.length - 1;
+                                startButton.disabled = currentIndex === 0;
                                 backButton.disabled = currentIndex === 0;
+                                forwardButton.disabled = currentIndex === skins2.length - 1;
+                                endButton.disabled = currentIndex >= skins2.length - 1;
                                 fightButton.disabled = skins2[currentIndex].playersSkins[0].isExhausted;
                                 allInButton.disabled = skins2[currentIndex].playersSkins[0].isExhausted;
 
@@ -289,7 +328,7 @@ export class Fight extends NoxCommand {
                                     embeds: [await this.generateEmbed(skins2, currentIndex, guildId)],
                                     components: [
                                         new MessageActionRow({
-                                            components: [...([backButton]), ...([forwardButton])]
+                                            components: [...([startButton]), ...([backButton]), ...([forwardButton]), ...([endButton])]
                                         }),
                                         new MessageActionRow({
                                             components: fightComponents

--- a/src/commands/Smite/CCG/Fight.ts
+++ b/src/commands/Smite/CCG/Fight.ts
@@ -321,19 +321,19 @@ export class Fight extends NoxCommand {
                                 let god2Health = god2.health;
 
                                 let skinId1 = 0;
-                                for (let i = 0; i < skins1.length; i++) {
-                                    if (skins1[i].name === skinName1 && skins1[i].god.name === godName1) {
-                                        skinId1 = skins1[i].id;
-                                        skin1 = skins1[i];
+                                for (let skin of skins1) {
+                                    if (skin.name === skinName1 && skin.god.name === godName1) {
+                                        skinId1 = skin.id;
+                                        skin1 = skin;
                                         break;
                                     }
                                 }
 
                                 let skinId2 = 0;
-                                for (let i = 0; i < skins2.length; i++) {
-                                    if (skins2[i].name === skinName2 && skins2[i].god.name === godName2) {
-                                        skinId2 = skins2[i].id;
-                                        skin2 = skins2[i];
+                                for (let skin of skins2) {
+                                    if (skin.name === skinName2 && skin.god.name === godName2) {
+                                        skinId2 = skin.id;
+                                        skin2 = skin;
                                         break;
                                     }
                                 }

--- a/src/commands/Smite/CCG/Trade.ts
+++ b/src/commands/Smite/CCG/Trade.ts
@@ -216,17 +216,17 @@ export class Trade extends NoxCommand {
                                 collector3.stop();
                             } else if (react.emoji.name === '✅') {
                                 let skinId1 = 0;
-                                for (let i = 0; i < skins1.length; i++) {
-                                    if (skins1[i].name === skinName1) {
-                                        skinId1 = skins1[i].id;
+                                for (let skin of skins1) {
+                                    if (skin.name === skinName1 && skin.god.name === godName1) {
+                                        skinId1 = skin.id;
                                         break;
                                     }
                                 }
 
                                 let skinId2 = 0;
-                                for (let i = 0; i < skins2.length; i++) {
-                                    if (skins2[i].name === skinName2) {
-                                        skinId2 = skins2[i].id;
+                                for (let skin of skins2) {
+                                    if (skin.name === skinName2 && skin.god.name === godName2) {
+                                        skinId2 = skin.id;
                                         break;
                                     }
                                 }

--- a/src/commands/Smite/CCG/Wishlist.ts
+++ b/src/commands/Smite/CCG/Wishlist.ts
@@ -1,9 +1,10 @@
 import { createPlayerIfNotExists } from '@lib/database/utils/PlayersUtils';
 import { disconnectWishlistSkin, getSkinOwner, getSkinWishlist } from '@lib/database/utils/SkinsUtils';
 import { PlayerNotLoadedError } from '@lib/structures/errors/PlayerNotLoadedError';
+import { WrongInteractionError } from '@lib/structures/errors/WrongInteractionError';
 import { NoxCommand } from '@lib/structures/NoxCommand';
 import { NoxCommandOptions } from '@lib/structures/NoxCommandOptions';
-import { getBackButton, getForwardButton, getSelectButton } from '@lib/utils/PaginationUtils';
+import { getBackButton, getEndButton, getForwardButton, getSelectButton, getStartButton } from '@lib/utils/PaginationUtils';
 import { generateSkinEmbed } from '@lib/utils/smite/SkinsPaginationUtils';
 import { ApplyOptions } from '@sapphire/decorators';
 import { ApplicationCommandRegistry, ChatInputCommand } from '@sapphire/framework';
@@ -38,6 +39,8 @@ export class Wishlist extends NoxCommand {
         const backButton = getBackButton();
         const forwardButton = getForwardButton();
         const selectButton = getSelectButton('Remove', 'DANGER');
+        const endButton = getEndButton();
+        const startButton = getStartButton();
 
         let skins = await getSkinWishlist(player.id);
         if (!skins || skins.length === 0) {
@@ -52,21 +55,34 @@ export class Wishlist extends NoxCommand {
                 })
         }
 
-        skins.length <= 1
-            ? forwardButton.setDisabled(true)
-            : forwardButton.setDisabled(false);
+        if (skins.length <= 1) {
+            forwardButton.setDisabled(true);
+            endButton.setDisabled(true);
+        } else {
+            forwardButton.setDisabled(false);
+            endButton.setDisabled(false);
+        }
+
+        let messageActionRows = user.id === author.id
+            ? [
+                new MessageActionRow({
+                    components: [...([startButton]), ...([backButton]), ...([forwardButton]), ...([endButton])]
+                }),
+                new MessageActionRow({
+                    components: [...([selectButton])]
+                })
+            ]
+            : [
+                new MessageActionRow({
+                    components: [...([startButton]), ...([backButton]), ...([forwardButton]), ...([endButton])]
+                })
+            ];
 
         let currentIndex = 0
         const reply = await interaction.reply({
             content: `${user}'s wishlist:`,
             embeds: [await this.generateGodSkinEmbed(skins, currentIndex, guildId)],
-            components: [
-                new MessageActionRow({
-                    components: user.id === author.id
-                        ? [...([backButton]), ...([selectButton]), ...([forwardButton])]
-                        : [...([backButton]), ...([forwardButton])]
-                })
-            ],
+            components: messageActionRows,
             fetchReply: true
         }) as Message;
 
@@ -74,78 +90,78 @@ export class Wishlist extends NoxCommand {
             filter: ({ user }) => user.id === author.id
         });
         collector.on('collect', async interaction => {
-            if (interaction.customId === backButton.customId || interaction.customId === forwardButton.customId) {
-                // Increase/decrease index
-                switch (interaction.customId) {
-                    case backButton.customId:
-                        if (currentIndex > 0) {
-                            currentIndex -= 1;
-                        }
-                        break;
-                    case forwardButton.customId:
-                        if (currentIndex < skins.length - 1) {
-                            currentIndex += 1;
-                        }
-                        break;
-                }
-
-                // Disable the buttons if they cannot be used
-                forwardButton.disabled = currentIndex === skins.length - 1;
-                backButton.disabled = currentIndex === 0;
-
-                // Respond to interaction by updating message with new embed
-                await interaction.update({
-                    embeds: [await this.generateGodSkinEmbed(skins, currentIndex, guildId)],
-                    components: [
-                        new MessageActionRow({
-                            components: user.id === author.id
-                                ? [...([backButton]), ...([selectButton]), ...([forwardButton])]
-                                : [...([backButton]), ...([forwardButton])]
-                        })
-                    ]
-                })
-            } else if (interaction.customId === selectButton.customId && user.id === author.id) {
-                let skinName = interaction.message.embeds[0].title;
-
-                let skinId = 0;
-                for (let i = 0; i < skins.length; i++) {
-                    if (skins[i].name === skinName) {
-                        skinId = skins[i].id;
-                        break;
-                    }
-                }
-
-                let playerWishedSkin = await disconnectWishlistSkin(skinId, player.id);
-                this.container.logger.info(`The card ${skinName}<${playerWishedSkin.skinId}> was removed from the wishlist of ${user.username}#${user.discriminator}<${user.id}>!`);
-                skins = await getSkinWishlist(player.id);
-
-                if (skins == null || skins.length === 0) {
-                    collector.stop();
-                } else {
-                    // Reload the skins embed
+            // Increase/decrease index
+            switch (interaction.customId) {
+                case startButton.customId:
+                    currentIndex = 0;
+                    break;
+                case backButton.customId:
                     if (currentIndex > 0) {
                         currentIndex -= 1;
                     }
-                    // Disable the buttons if they cannot be used
-                    forwardButton.disabled = currentIndex === skins.length - 1;
-                    backButton.disabled = currentIndex === 0;
+                    break;
+                case forwardButton.customId:
+                    if (currentIndex < skins.length - 1) {
+                        currentIndex += 1;
+                    }
+                    break;
+                case endButton.customId:
+                    currentIndex = skins.length - 1;
+                    break;
+                case selectButton.customId:
+                    for (let skin of skins) {
+                        if (skin.name === interaction.message.embeds[0].title && skin.god.name === interaction.message.embeds[0].author.name) {
+                            await disconnectWishlistSkin(skin.id, player.id)
+                            break;
+                        }
+                    }
+                    if (currentIndex != 0 && currentIndex === skins.length - 1) {
+                        currentIndex--;
+                    }
+                    skins = await getSkinWishlist(player.id);
+                    break;
+                default:
+                    throw new WrongInteractionError({
+                        interaction: interaction
+                    });
+            }
 
-                    await interaction.update({
-                        embeds: [await this.generateGodSkinEmbed(skins, currentIndex, guildId)],
-                        components: [
-                            new MessageActionRow({
-                                components: [...([backButton]), ...([selectButton]), ...([forwardButton])]
-                            })
-                        ]
-                    })
-                }
+
+            if (skins == null || skins.length === 0) {
+                collector.stop()
+            } else {
+                // Disable the buttons if they cannot be used
+                startButton.disabled = currentIndex === 0;
+                forwardButton.disabled = currentIndex === skins.length - 1;
+                backButton.disabled = currentIndex === 0;
+                endButton.disabled = currentIndex >= skins.length - 1;
+
+                messageActionRows = user.id === author.id
+                    ? [
+                        new MessageActionRow({
+                            components: [...([startButton]), ...([backButton]), ...([forwardButton]), ...([endButton])]
+                        }),
+                        new MessageActionRow({
+                            components: [...([selectButton])]
+                        })
+                    ]
+                    : [
+                        new MessageActionRow({
+                            components: [...([startButton]), ...([backButton]), ...([forwardButton]), ...([endButton])]
+                        })
+                    ];
+                // Respond to interaction by updating message with new embed
+                await interaction.update({
+                    embeds: [await this.generateGodSkinEmbed(skins, currentIndex, guildId)],
+                    components: messageActionRows
+                })
             }
         });
 
         collector.on('end', collected => {
             if (skins == null || skins.length === 0) {
                 reply.edit({
-                    content: 'Your wishlist is empty!',
+                    content: 'Your wishlist is now empty!',
                     embeds: [],
                     components: []
                 });

--- a/src/lib/structures/errors/WrongInteractionError.ts
+++ b/src/lib/structures/errors/WrongInteractionError.ts
@@ -1,0 +1,12 @@
+import { NoxError } from "@lib/structures/errors/NoxError";
+import { WrongInteractionInterface } from "./interfaces/WrongInteractionErrorInterface";
+
+export class WrongInteractionError extends NoxError {
+
+    public constructor(context: WrongInteractionInterface.Context) {
+        super({
+            identifier: 'wrongInteractionError',
+            context: context
+        });
+    }
+}

--- a/src/lib/structures/errors/interfaces/WrongInteractionErrorInterface.ts
+++ b/src/lib/structures/errors/interfaces/WrongInteractionErrorInterface.ts
@@ -1,0 +1,12 @@
+import { Interaction } from "discord.js";
+
+export declare namespace WrongInteractionInterface {
+    interface Options {
+        identifier: string;
+        message?: string;
+        context: Context;
+    }
+    interface Context {
+        interaction: Interaction;
+    }
+}

--- a/src/lib/utils/PaginationUtils.ts
+++ b/src/lib/utils/PaginationUtils.ts
@@ -35,6 +35,13 @@ export function getFavoriteButton(
 ) {
     return getButton(customId, label, style, '🤍');
 }
+export function getRemoveFromWishlistButton(
+    label: string = 'Unwish',
+    customId: string = 'removewishlist',
+    style: MessageButtonStyle | null = 'DANGER'
+) {
+    return getButton(customId, label, style);
+}
 export function getSelectButton(
     label: string | null = null,
     style: MessageButtonStyle | null = null,


### PR DESCRIPTION
### QOL

- Added a _'Start'_ and _'End'_ buttons to paginated embeds, so it is easier to navigate.
Commands affected are `/fight`, `/trade`, `/skins`, `/team` and `/wishlist`.

### Bug fixes

- Fixed an issue when trading skins where two skins with the same name would get mixed up.