### PR TITLE
Release/v3.1.1

### DIFF
--- a/prisma/migrations/20220121160229_added_commands/migration.sql
+++ b/prisma/migrations/20220121160229_added_commands/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "Commands" (
+    "name" TEXT NOT NULL,
+
+    CONSTRAINT "Commands_pkey" PRIMARY KEY ("name")
+);
+
+-- CreateTable
+CREATE TABLE "GuildsCommands" (
+    "guildId" TEXT NOT NULL,
+    "commandName" TEXT NOT NULL,
+    "authorizedChannelIds" TEXT[],
+
+    CONSTRAINT "GuildsCommands_pkey" PRIMARY KEY ("guildId","commandName")
+);
+
+-- AddForeignKey
+ALTER TABLE "GuildsCommands" ADD CONSTRAINT "GuildsCommands_guildId_fkey" FOREIGN KEY ("guildId") REFERENCES "Guilds"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GuildsCommands" ADD CONSTRAINT "GuildsCommands_commandName_fkey" FOREIGN KEY ("commandName") REFERENCES "Commands"("name") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,11 +18,27 @@ model Users {
 }
 
 model Guilds {
-    id       String    @id
-    season   Int       @default(1)
-    isActive Boolean   @default(true)
-    users    Users[]
-    players  Players[]
+    id             String           @id
+    season         Int              @default(1)
+    isActive       Boolean          @default(true)
+    users          Users[]
+    players        Players[]
+    GuildsCommands GuildsCommands[]
+}
+
+model Commands {
+    name           String           @id
+    GuildsCommands GuildsCommands[]
+}
+
+model GuildsCommands {
+    guild                Guilds   @relation(fields: [guildId], references: [id])
+    guildId              String
+    command              Commands @relation(fields: [commandName], references: [name])
+    commandName          String
+    authorizedChannelIds String[]
+
+    @@id([guildId, commandName])
 }
 
 model Items {

--- a/src/commands/Admin/Commands/ListCommandChannels.ts
+++ b/src/commands/Admin/Commands/ListCommandChannels.ts
@@ -1,0 +1,53 @@
+import { createIfNotExists, getCommandAuthorizedChannels } from '@lib/database/utils/CommandsUtils';
+import { QueryNotFoundError } from '@lib/structures/errors/QueryNotFoundError';
+import { NoxCommand } from '@lib/structures/NoxCommand';
+import { NoxCommandOptions } from '@lib/structures/NoxCommandOptions';
+import { ApplyOptions } from '@sapphire/decorators';
+import { ApplicationCommandRegistry, ChatInputCommand } from '@sapphire/framework';
+import type { CommandInteraction } from 'discord.js';
+
+@ApplyOptions<NoxCommandOptions>({
+    requiredUserPermissions: 'BAN_MEMBERS',
+    description: 'Lists a command\s authorized channels.'
+})
+export class LockCommand extends NoxCommand {
+
+    public override async chatInputRun(interaction: CommandInteraction, context: ChatInputCommand.RunContext) {
+        const { guildId } = interaction;
+
+        const commandName = interaction.options.getString('command', true);
+        const command = this.container.stores.get('commands').get(commandName);
+        if (command == null) {
+            throw new QueryNotFoundError({
+                query: commandName
+            });
+        }
+        await createIfNotExists(command.name, guildId);
+
+        const channels = await getCommandAuthorizedChannels(command.name, guildId);
+
+        const replyMsg = channels.length > 0
+            ? `The command \`${command.name}\` can be used in the following channels:\n  • ${channels.join('\n  • ')}`
+            : `The command \`${command.name}\` can be used in every channels.`
+
+        return await interaction.reply(replyMsg);
+    }
+
+    public override registerApplicationCommands(registry: ApplicationCommandRegistry) {
+        registry.registerChatInputCommand({
+            name: this.name,
+            description: this.description,
+            options: [
+                {
+                    name: 'command',
+                    description: 'The command\'s name',
+                    type: 'STRING',
+                    required: true,
+                    autocomplete: true
+                }
+            ]
+        }, {
+            guildIds: this.guildIds
+        });
+    }
+}

--- a/src/commands/Admin/Commands/LockCommand.ts
+++ b/src/commands/Admin/Commands/LockCommand.ts
@@ -32,7 +32,8 @@ export class LockCommand extends NoxCommand {
                 const children = channel.children.map(child => child.id);
                 let isAllChildrenInParent = true;
                 for (let channelId of children) {
-                    if (!authorizedChannelIds.includes(channelId)) {
+                    const channel = await this.container.client.channels.fetch(channelId);
+                    if (channel.type === 'GUILD_TEXT' && !authorizedChannelIds.includes(channelId)) {
                         authorizedChannelIds.push(channelId);
                         isAllChildrenInParent = false;
                     }
@@ -89,7 +90,7 @@ export class LockCommand extends NoxCommand {
         const replyMsg = channels.length > 0
             ? `The command \`${command.name}\` is now locked to the following channels:\n  • ${channels.join('\n  • ')}`
             : `The command \`${command.name}\` is now available in every channels.`
-            
+
         return await interaction.reply(replyMsg);
     }
 

--- a/src/commands/Admin/Commands/LockCommand.ts
+++ b/src/commands/Admin/Commands/LockCommand.ts
@@ -1,0 +1,123 @@
+import { createIfNotExists } from '@lib/database/utils/CommandsUtils';
+import { QueryNotFoundError } from '@lib/structures/errors/QueryNotFoundError';
+import { NoxCommand } from '@lib/structures/NoxCommand';
+import { NoxCommandOptions } from '@lib/structures/NoxCommandOptions';
+import { ApplyOptions } from '@sapphire/decorators';
+import { ApplicationCommandRegistry, ChatInputCommand } from '@sapphire/framework';
+import type { CommandInteraction } from 'discord.js';
+
+@ApplyOptions<NoxCommandOptions>({
+    requiredUserPermissions: 'ADMINISTRATOR',
+    description: 'Locks a command to a channel.'
+})
+export class LockCommand extends NoxCommand {
+
+    public override async chatInputRun(interaction: CommandInteraction, context: ChatInputCommand.RunContext) {
+        const { guildId } = interaction;
+
+        const commandName = interaction.options.getString('command', true);
+        const command = this.container.stores.get('commands').get(commandName);
+        if (command == null) {
+            throw new QueryNotFoundError({
+                query: commandName
+            });
+        }
+
+        const channel = interaction.options.getChannel('channel', true);
+        const guildCommand = await createIfNotExists(command.name, guildId);
+
+        const authorizedChannelIds = guildCommand.authorizedChannelIds;
+        switch (channel.type) {
+            case 'GUILD_CATEGORY': {
+                const children = channel.children.map(child => child.id);
+                let isAllChildrenInParent = true;
+                for (let channelId of children) {
+                    if (!authorizedChannelIds.includes(channelId)) {
+                        authorizedChannelIds.push(channelId);
+                        isAllChildrenInParent = false;
+                    }
+                }
+                if (isAllChildrenInParent) {
+                    for (let channelId of children) {
+                        authorizedChannelIds.splice(authorizedChannelIds.indexOf(channelId), 1);
+                    }
+                }
+
+                await this.container.prisma.guildsCommands.update({
+                    data: {
+                        authorizedChannelIds: authorizedChannelIds
+                    },
+                    where: {
+                        guildId_commandName: {
+                            commandName: command.name,
+                            guildId: guildId
+                        }
+                    }
+                });
+                break;
+            }
+            case 'GUILD_TEXT': {
+                if (!authorizedChannelIds.includes(channel.id)) {
+                    authorizedChannelIds.push(channel.id);
+                } else {
+                    authorizedChannelIds.splice(authorizedChannelIds.indexOf(channel.id), 1);
+                }
+
+                await this.container.prisma.guildsCommands.update({
+                    data: {
+                        authorizedChannelIds: authorizedChannelIds
+                    },
+                    where: {
+                        guildId_commandName: {
+                            commandName: command.name,
+                            guildId: guildId
+                        }
+                    }
+                });
+                break;
+            }
+            default: {
+                return await interaction.reply('The channel parameter can either be a `Text Channel`  or a `Category channel`.')
+            }
+        }
+
+        const channels = [];
+        for (let channelId of authorizedChannelIds) {
+            channels.push(await this.container.client.channels.fetch(channelId));
+        }
+
+        const replyMsg = channels.length > 0
+            ? `The command \`${command.name}\` is now locked to the following channels:\n  • ${channels.join('\n  • ')}`
+            : `The command \`${command.name}\` is now available in every channels.`
+            
+        return await interaction.reply(replyMsg);
+    }
+
+    public override registerApplicationCommands(registry: ApplicationCommandRegistry) {
+        registry.registerChatInputCommand({
+            name: this.name,
+            description: this.description,
+            options: [
+                {
+                    name: 'command',
+                    description: 'The command\'s name',
+                    type: 'STRING',
+                    required: true,
+                    autocomplete: true
+                },
+                {
+                    name: 'channel',
+                    description: 'The channel\'s name.',
+                    type: 'CHANNEL',
+                    channelTypes: [
+                        'GUILD_CATEGORY',
+                        'GUILD_TEXT'
+                    ],
+                    required: true
+                }
+            ]
+        }, {
+            guildIds: this.guildIds
+        });
+    }
+}

--- a/src/commands/Admin/Commands/ReloadCommands.ts
+++ b/src/commands/Admin/Commands/ReloadCommands.ts
@@ -1,7 +1,7 @@
 import { NoxCommand } from '@lib/structures/NoxCommand';
 import { NoxCommandOptions } from '@lib/structures/NoxCommandOptions';
 import { ApplyOptions } from '@sapphire/decorators';
-import { ApplicationCommandRegistry, ChatInputCommand, RegisterBehavior } from '@sapphire/framework';
+import { ApplicationCommandRegistry, ChatInputCommand } from '@sapphire/framework';
 import type { CommandInteraction } from 'discord.js';
 
 @ApplyOptions<NoxCommandOptions>({
@@ -46,12 +46,14 @@ export class ReloadCommands extends NoxCommand {
         registry.registerChatInputCommand({
             name: this.name,
             description: this.description,
-            options: [{
-                name: 'command',
-                description: 'The command\'s name',
-                type: 'STRING',
-                autocomplete: true
-            }]
+            options: [
+                {
+                    name: 'command',
+                    description: 'The command\'s name',
+                    type: 'STRING',
+                    autocomplete: true
+                }
+            ]
         }, {
             guildIds: this.guildIds
         });

--- a/src/commands/Smite/CCG/Player.ts
+++ b/src/commands/Smite/CCG/Player.ts
@@ -8,7 +8,7 @@ import { NoxCommandOptions } from '@lib/structures/NoxCommandOptions';
 import { Players } from '@prisma/client';
 import { ApplyOptions } from '@sapphire/decorators';
 import { ApplicationCommandRegistry, ChatInputCommand } from '@sapphire/framework';
-import { CommandInteraction, Guild, Message, MessageEmbed, User } from 'discord.js';
+import { CommandInteraction, MessageEmbed, User } from 'discord.js';
 
 @ApplyOptions<NoxCommandOptions>({
     description: 'Shows a player\'s statistics.',
@@ -84,6 +84,7 @@ export class Player extends NoxCommand {
             `Claimed: \`${player.claimedCards}\`\n` +
             `Stolen: \`${player.cardsStolen}\`\n` +
             `Given: \`${player.cardsGiven}\`\n` +
+            `Received: \`${player.cardsReceived}\`\n` +
             `Exchanged: \`${player.cardsExchanged}\``,
             true
         );
@@ -151,6 +152,7 @@ export class Player extends NoxCommand {
             `Claimed: \`${playerSeasonsArchive.claimedCards}\`\n` +
             `Stolen: \`${playerSeasonsArchive.cardsStolen}\`\n` +
             `Given: \`${playerSeasonsArchive.cardsGiven}\`\n` +
+            `Received: \`${playerSeasonsArchive.cardsReceived}\`\n` +
             `Exchanged: \`${playerSeasonsArchive.cardsExchanged}\``,
             true
         );

--- a/src/commands/Smite/CCG/Roll.ts
+++ b/src/commands/Smite/CCG/Roll.ts
@@ -100,8 +100,7 @@ export class Roll extends NoxCommand {
             } else if (!canClaim) {
                 const duration = await getTimeLeftBeforeClaim(player.id);
                 interaction.followUp({
-                    content: `${user} You have to wait \`${duration.hours()} hour(s), ${duration.minutes()} minutes and ${duration.seconds()} seconds\` before claiming a new card again.`,
-                    ephemeral: true
+                    content: `${user} You have to wait \`${duration.hours()} hour(s), ${duration.minutes()} minutes and ${duration.seconds()} seconds\` before claiming a new card again.`
                 });
             } else {
                 collector.stop();

--- a/src/commands/Smite/CCG/Team.ts
+++ b/src/commands/Smite/CCG/Team.ts
@@ -51,6 +51,8 @@ export class Team extends NoxCommand {
             });
         }
 
+        let currentIndex = 0
+
         skins[0].playersSkins[0].isFavorite
             ? favoriteButton.setEmoji('💔')
             : favoriteButton.setEmoji('❤️');
@@ -70,7 +72,6 @@ export class Team extends NoxCommand {
                 })
             ];
 
-        let currentIndex = 0
         const embedMessage1 = await interaction.reply({
             content: `${user}'s team:`,
             embeds: [await this.generateEmbed(skins, currentIndex, guildId)],
@@ -140,6 +141,9 @@ export class Team extends NoxCommand {
                 forwardButton.disabled = currentIndex === skins.length - 1;
                 backButton.disabled = currentIndex === 0;
                 endButton.disabled = currentIndex >= skins.length - 1;
+                skins[currentIndex].playersSkins[0].isFavorite
+                    ? favoriteButton.setEmoji('💔')
+                    : favoriteButton.setEmoji('❤️');
 
                 const messageActionRows = user.id === author.id
                     ? [

--- a/src/lib/database/utils/CommandsUtils.ts
+++ b/src/lib/database/utils/CommandsUtils.ts
@@ -10,7 +10,10 @@ export async function isCommandAuthorizedInChannel(commandName: string, guildId:
             }
         }
     });
-    return guildCommand.authorizedChannelIds.includes(channelId);
+    
+    return guildCommand.authorizedChannelIds == null
+        || guildCommand.authorizedChannelIds.length <= 0
+        || guildCommand.authorizedChannelIds.includes(channelId);
 }
 
 export async function getGuildCommand(commandName: string, guildId: Snowflake) {

--- a/src/lib/database/utils/CommandsUtils.ts
+++ b/src/lib/database/utils/CommandsUtils.ts
@@ -1,0 +1,65 @@
+import { container } from "@sapphire/framework";
+import { Snowflake } from "discord.js";
+
+export async function isCommandAuthorizedInChannel(commandName: string, guildId: Snowflake, channelId: Snowflake): Promise<boolean> {
+    const guildCommand = await container.prisma.guildsCommands.findUnique({
+        where: {
+            guildId_commandName: {
+                commandName: commandName,
+                guildId: guildId
+            }
+        }
+    });
+    return guildCommand.authorizedChannelIds.includes(channelId);
+}
+
+export async function getGuildCommand(commandName: string, guildId: Snowflake) {
+    return await container.prisma.guildsCommands.findUnique({
+        where: {
+            guildId_commandName: {
+                commandName: commandName,
+                guildId: guildId
+            }
+        }
+    });
+}
+
+export async function createIfNotExists(commandName: string, guildId: Snowflake) {
+    let guildCommand = await container.prisma.guildsCommands.findUnique({
+        where: {
+            guildId_commandName: {
+                commandName: commandName,
+                guildId: guildId
+            }
+        }
+    });
+
+    if (guildCommand == null) {
+        guildCommand = await container.prisma.guildsCommands.create({
+            data: {
+                command: {
+                    connectOrCreate: {
+                        create: {
+                            name: commandName
+                        },
+                        where: {
+                            name: commandName
+                        }
+                    }
+                },
+                guild: {
+                    connectOrCreate: {
+                        create: {
+                            id: guildId
+                        },
+                        where: {
+                            id: guildId
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    return guildCommand;
+}

--- a/src/lib/database/utils/CommandsUtils.ts
+++ b/src/lib/database/utils/CommandsUtils.ts
@@ -10,7 +10,7 @@ export async function isCommandAuthorizedInChannel(commandName: string, guildId:
             }
         }
     });
-    
+
     return guildCommand.authorizedChannelIds == null
         || guildCommand.authorizedChannelIds.length <= 0
         || guildCommand.authorizedChannelIds.includes(channelId);
@@ -65,4 +65,22 @@ export async function createIfNotExists(commandName: string, guildId: Snowflake)
     }
 
     return guildCommand;
+}
+
+export async function getCommandAuthorizedChannels(commandName: string, guildId: Snowflake) {
+    const guildCommand = await container.prisma.guildsCommands.findUnique({
+        where: {
+            guildId_commandName: {
+                commandName: commandName,
+                guildId: guildId
+            }
+        }
+    });
+
+    const channels = [];
+    for (let channelId of guildCommand.authorizedChannelIds) {
+        channels.push(await container.client.channels.fetch(channelId));
+    }
+
+    return channels;
 }

--- a/src/preconditions/CommandExistsInDatabase.ts
+++ b/src/preconditions/CommandExistsInDatabase.ts
@@ -1,0 +1,35 @@
+import { createIfNotExists } from '@lib/database/utils/CommandsUtils';
+import { ApplyOptions } from '@sapphire/decorators';
+import { AsyncPreconditionResult, ChatInputCommand, ContextMenuCommand, Precondition, PreconditionOptions } from '@sapphire/framework';
+import type { CommandInteraction, ContextMenuInteraction } from 'discord.js';
+
+@ApplyOptions<PreconditionOptions>({
+    name: 'commandExistsInDatabase',
+    position: 10
+})
+export class CommandExistsInDatabase extends Precondition {
+
+    public override async chatInputRun(interaction: CommandInteraction, command: ChatInputCommand, context: Precondition.Context): AsyncPreconditionResult {
+        if (!(await this.commandExistsInDatabase(interaction))) {
+            return this.error({
+                message: `An error occured when trying to load the command.`
+            });
+        }
+
+        return this.ok();
+    }
+
+    public override async contextMenuRun(interaction: ContextMenuInteraction, command: ContextMenuCommand, context: Precondition.Context) {
+        if (!(await this.commandExistsInDatabase(interaction))) {
+            return this.error({
+                message: `An error occured when trying to load the command.`
+            });
+        }
+
+        return this.ok();
+    }
+
+    private async commandExistsInDatabase(interaction: CommandInteraction | ContextMenuInteraction): Promise<boolean> {
+        return await createIfNotExists(interaction.command.name, interaction.guildId) != null;
+    }
+}

--- a/src/preconditions/CommandIsAuthorizedInChannel.ts
+++ b/src/preconditions/CommandIsAuthorizedInChannel.ts
@@ -1,0 +1,53 @@
+import { isCommandAuthorizedInChannel } from '@lib/database/utils/CommandsUtils';
+import { ApplyOptions } from '@sapphire/decorators';
+import { AsyncPreconditionResult, ChatInputCommand, ContextMenuCommand, Precondition, PreconditionOptions } from '@sapphire/framework';
+import type { CommandInteraction, ContextMenuInteraction } from 'discord.js';
+
+@ApplyOptions<PreconditionOptions>({
+    name: 'commandIsAuthorizedInChannel',
+    position: 20
+})
+export class CommandIsAuthorizedInChannel extends Precondition {
+
+    public override async chatInputRun(interaction: CommandInteraction, command: ChatInputCommand, context: Precondition.Context): AsyncPreconditionResult {
+        if (!(await this.commandIsAuthorized(interaction))) {
+            return this.error({
+                message: await this.getChannelsAvailableMessage(interaction)
+            });
+        }
+
+        return this.ok();
+    }
+
+    public override async contextMenuRun(interaction: ContextMenuInteraction, command: ContextMenuCommand, context: Precondition.Context) {
+        if (!(await this.commandIsAuthorized(interaction))) {
+            return this.error({
+                message: await this.getChannelsAvailableMessage(interaction)
+            });
+        }
+
+        return this.ok();
+    }
+
+    private async getChannelsAvailableMessage(interaction: CommandInteraction | ContextMenuInteraction) {
+        const guildCommand = await this.container.prisma.guildsCommands.findUnique({
+            where: {
+                guildId_commandName: {
+                    commandName: interaction.commandName,
+                    guildId: interaction.guildId
+                }
+            }
+        });
+
+        const channels = [];
+        for (let channelId of guildCommand.authorizedChannelIds) {
+            channels.push(await this.container.client.channels.fetch(channelId));
+        }
+
+        return `This command can only be used in the following channels:\n  • ${channels.join('\n  • ')}`
+    }
+
+    private async commandIsAuthorized(interaction: CommandInteraction | ContextMenuInteraction): Promise<boolean> {
+        return await isCommandAuthorizedInChannel(interaction.command.name, interaction.guildId, interaction.channelId);
+    }
+}


### PR DESCRIPTION
### Features

- Added commands to lock other commands to specific channels.
This feature will probably become deprecated when [permissions v2](https://msciotti.notion.site/msciotti/Command-Permissions-V2-4d113cb49090409f998f3bd80a06c3bd) are released and adapted to [Sapphire](https://www.sapphirejs.dev/).

### Bug fix

- Added missing _"Cards Received"_ statistics to the `/player` command.
- Fixed an issue where the _"Favorite"_ button emoji would show as a broken heart on skins that are not set as favorite.
- Fixed an issue where only the player who rolled a skin could see the timeout message of other users _(reverted so it is not an ephemeral message anymore)_