### PR TITLE
Release/v3.1.2

### DIFF
--- a/prisma/views.sql
+++ b/prisma/views.sql
@@ -1,6 +1,6 @@
 CREATE OR REPLACE VIEW GodsAmountByPlayers
 AS
-SELECT DISTINCT "PlayersSkins"."playerId", "Guilds"."id" as "guildId", count("Skins"."godId")
+SELECT DISTINCT "PlayersSkins"."playerId", "Guilds"."id" as "guildId", count(distinct "Gods"."id")
 FROM "PlayersSkins", "Skins", "Gods", "Guilds", "Players"
 WHERE "PlayersSkins"."skinId" = "Skins"."id"
 AND "Skins"."godId" = "Gods"."id"
@@ -10,6 +10,17 @@ AND "Guilds"."id" = "Players"."guildId"
 GROUP BY "Guilds"."id", "PlayersSkins"."playerId"
 ORDER BY 3 DESC;
 
+CREATE OR REPLACE VIEW PlayerSkinsAmountByGod
+AS
+select gu.id as "guildId", p.id as "playerId", g.id as "godId", count(s.id) as "skinsAmount"
+from "Guilds" gu, "Players" p, "PlayersSkins" ps, "Skins" s, "Gods" g
+where gu.id = p."guildId"
+and p.id = ps."playerId"
+and ps."skinId" = s.id 
+and s."godId" = g.id
+group by 1, 2, 3
+order by 4 desc;
+
 CREATE OR REPLACE VIEW GodSkinsFullNames
 AS
 select '"' || "Skins"."name" || '" ' || "Gods"."name" as "fullName", "Gods"."id" as "godId", "Skins"."id" as "skinId"
@@ -17,3 +28,64 @@ from "Skins", "Gods"
 where "Skins"."godId" = "Gods"."id"
 group by "Gods"."name", "Skins"."name", "Skins"."id", "Gods"."id"
 order by "Gods"."name", "Skins"."name";
+
+-- Role by players
+CREATE OR REPLACE VIEW HunterGodsByPlayers
+AS
+select gu.id as "guildId", p.id as "playerId", count(distinct g.id) as "godsAmount"
+from "Guilds" gu, "Players" p, "PlayersSkins" ps, "Skins" s, "Gods" g
+where gu.id = p."guildId"
+and p.id = ps."playerId"
+and ps."skinId" = s.id 
+and s."godId" = g.id
+and g.roles = 'Hunter'
+group by 1, 2
+order by 3 desc;
+
+CREATE OR REPLACE VIEW GuardianGodsByPlayers
+AS
+select gu.id as "guildId", p.id as "playerId", count(distinct g.id) as "godsAmount"
+from "Guilds" gu, "Players" p, "PlayersSkins" ps, "Skins" s, "Gods" g
+where gu.id = p."guildId"
+and p.id = ps."playerId"
+and ps."skinId" = s.id 
+and s."godId" = g.id
+and g.roles = 'Guardian'
+group by 1, 2
+order by 3 desc;
+
+CREATE OR REPLACE VIEW AssassinGodsByPlayers
+AS
+select gu.id as "guildId", p.id as "playerId", count(distinct g.id) as "godsAmount"
+from "Guilds" gu, "Players" p, "PlayersSkins" ps, "Skins" s, "Gods" g
+where gu.id = p."guildId"
+and p.id = ps."playerId"
+and ps."skinId" = s.id 
+and s."godId" = g.id
+and g.roles = 'Assassin'
+group by 1, 2
+order by 3 desc;
+
+CREATE OR REPLACE VIEW MageGodsByPlayers
+AS
+select gu.id as "guildId", p.id as "playerId", count(distinct g.id) as "godsAmount"
+from "Guilds" gu, "Players" p, "PlayersSkins" ps, "Skins" s, "Gods" g
+where gu.id = p."guildId"
+and p.id = ps."playerId"
+and ps."skinId" = s.id 
+and s."godId" = g.id
+and g.roles = 'Mage'
+group by 1, 2
+order by 3 desc;
+
+CREATE OR REPLACE VIEW WarriorGodsByPlayers
+AS
+select gu.id as "guildId", p.id as "playerId", count(distinct g.id) as "godsAmount"
+from "Guilds" gu, "Players" p, "PlayersSkins" ps, "Skins" s, "Gods" g
+where gu.id = p."guildId"
+and p.id = ps."playerId"
+and ps."skinId" = s.id 
+and s."godId" = g.id
+and g.roles = 'Warrior'
+group by 1, 2
+order by 3 desc;

--- a/src/achievements/AssassinMain.ts
+++ b/src/achievements/AssassinMain.ts
@@ -1,0 +1,24 @@
+import { Achievement } from "@lib/achievements/Achievement";
+import { AchievementOptions } from "@lib/achievements/interfaces/AchievementInterface";
+import { GodsRoleByPlayers } from "@lib/database/interfaces/ViewsInterfaces";
+import { ApplyOptions } from "@sapphire/decorators";
+import { container } from "@sapphire/framework";
+import { Snowflake } from "discord-api-types";
+
+@ApplyOptions<AchievementOptions>({
+    description: 'Have at least 15 different assassin gods in your team.',
+    tokens: 8
+})
+export class AssassinMain extends Achievement {
+
+    async getCurrentPlayerIds(guildId: Snowflake): Promise<number[]> {
+        const rows: GodsRoleByPlayers = await container.prisma.$queryRaw`select * from assassingodsbyplayers g where "guildId" = ${guildId} and "godsAmount" >= ${15} order by "godsAmount" desc;`;
+
+        const playerIds = [];
+        for (let row of rows) {
+            playerIds.push(row.playerId);
+        }
+
+        return playerIds;
+    }
+}

--- a/src/achievements/GuardianMain.ts
+++ b/src/achievements/GuardianMain.ts
@@ -1,0 +1,24 @@
+import { Achievement } from "@lib/achievements/Achievement";
+import { AchievementOptions } from "@lib/achievements/interfaces/AchievementInterface";
+import { GodsRoleByPlayers } from "@lib/database/interfaces/ViewsInterfaces";
+import { ApplyOptions } from "@sapphire/decorators";
+import { container } from "@sapphire/framework";
+import { Snowflake } from "discord-api-types";
+
+@ApplyOptions<AchievementOptions>({
+    description: 'Have at least 15 different guardian gods in your team.',
+    tokens: 8
+})
+export class GuardianMain extends Achievement {
+
+    async getCurrentPlayerIds(guildId: Snowflake): Promise<number[]> {
+        const rows: GodsRoleByPlayers = await container.prisma.$queryRaw`select * from guardiangodsbyplayers g where "guildId" = ${guildId} and "godsAmount" >= ${15} order by "godsAmount" desc;`;
+
+        const playerIds = [];
+        for (let row of rows) {
+            playerIds.push(row.playerId);
+        }
+
+        return playerIds;
+    }
+}

--- a/src/achievements/HunterMain.ts
+++ b/src/achievements/HunterMain.ts
@@ -1,0 +1,24 @@
+import { Achievement } from "@lib/achievements/Achievement";
+import { AchievementOptions } from "@lib/achievements/interfaces/AchievementInterface";
+import { GodsRoleByPlayers } from "@lib/database/interfaces/ViewsInterfaces";
+import { ApplyOptions } from "@sapphire/decorators";
+import { container } from "@sapphire/framework";
+import { Snowflake } from "discord-api-types";
+
+@ApplyOptions<AchievementOptions>({
+    description: 'Have at least 15 different hunter gods in your team.',
+    tokens: 8
+})
+export class HunterMain extends Achievement {
+
+    async getCurrentPlayerIds(guildId: Snowflake): Promise<number[]> {
+        const rows: GodsRoleByPlayers = await container.prisma.$queryRaw`select * from huntergodsbyplayers g where "guildId" = ${guildId} and "godsAmount" >= ${15} order by "godsAmount" desc;`;
+
+        const playerIds = [];
+        for (let row of rows) {
+            playerIds.push(row.playerId);
+        }
+
+        return playerIds;
+    }
+}

--- a/src/achievements/MageMain.ts
+++ b/src/achievements/MageMain.ts
@@ -1,0 +1,24 @@
+import { Achievement } from "@lib/achievements/Achievement";
+import { AchievementOptions } from "@lib/achievements/interfaces/AchievementInterface";
+import { GodsRoleByPlayers } from "@lib/database/interfaces/ViewsInterfaces";
+import { ApplyOptions } from "@sapphire/decorators";
+import { container } from "@sapphire/framework";
+import { Snowflake } from "discord-api-types";
+
+@ApplyOptions<AchievementOptions>({
+    description: 'Have at least 15 different mage gods in your team.',
+    tokens: 8
+})
+export class MageMain extends Achievement {
+
+    async getCurrentPlayerIds(guildId: Snowflake): Promise<number[]> {
+        const rows: GodsRoleByPlayers = await container.prisma.$queryRaw`select * from magegodsbyplayers g where "guildId" = ${guildId} and "godsAmount" >= ${15} order by "godsAmount" desc;`;
+
+        const playerIds = [];
+        for (let row of rows) {
+            playerIds.push(row.playerId);
+        }
+
+        return playerIds;
+    }
+}

--- a/src/achievements/OneTrickPony.ts
+++ b/src/achievements/OneTrickPony.ts
@@ -1,0 +1,24 @@
+import { Achievement } from "@lib/achievements/Achievement";
+import { AchievementOptions } from "@lib/achievements/interfaces/AchievementInterface";
+import { GodsAmountByPlayers, PlayerSkinsAmountByGod } from "@lib/database/interfaces/ViewsInterfaces";
+import { ApplyOptions } from "@sapphire/decorators";
+import { container } from "@sapphire/framework";
+import { Snowflake } from "discord-api-types";
+
+@ApplyOptions<AchievementOptions>({
+    description: 'Have at least 15 skins of a single god.',
+    tokens: 8
+})
+export class OneTrickPony extends Achievement {
+
+    async getCurrentPlayerIds(guildId: Snowflake): Promise<number[]> {
+        const rows: PlayerSkinsAmountByGod = await container.prisma.$queryRaw`select * from playerskinsamountbygod g where "guildId" = ${guildId} and "skinsAmount" >= ${15} order by "skinsAmount" desc;`;
+
+        const playerIds = [];
+        for (let row of rows) {
+            playerIds.push(row.playerId);
+        }
+
+        return playerIds;
+    }
+}

--- a/src/achievements/WarriorMain.ts
+++ b/src/achievements/WarriorMain.ts
@@ -1,0 +1,24 @@
+import { Achievement } from "@lib/achievements/Achievement";
+import { AchievementOptions } from "@lib/achievements/interfaces/AchievementInterface";
+import { GodsRoleByPlayers } from "@lib/database/interfaces/ViewsInterfaces";
+import { ApplyOptions } from "@sapphire/decorators";
+import { container } from "@sapphire/framework";
+import { Snowflake } from "discord-api-types";
+
+@ApplyOptions<AchievementOptions>({
+    description: 'Have at least 15 different warrior gods in your team.',
+    tokens: 8
+})
+export class WarriorMain extends Achievement {
+
+    async getCurrentPlayerIds(guildId: Snowflake): Promise<number[]> {
+        const rows: GodsRoleByPlayers = await container.prisma.$queryRaw`select * from warriorgodsbyplayers g where "guildId" = ${guildId} and "godsAmount" >= ${15} order by "godsAmount" desc;`;
+
+        const playerIds = [];
+        for (let row of rows) {
+            playerIds.push(row.playerId);
+        }
+
+        return playerIds;
+    }
+}

--- a/src/commands/Smite/CCG/Achievements.ts
+++ b/src/commands/Smite/CCG/Achievements.ts
@@ -58,7 +58,7 @@ export class Achievements extends NoxCommand {
                     }
                     break;
                 case forwardButton.customId:
-                    if (index < achievements.length - 6) {
+                    if (index < achievements.length - 5) {
                         index += 5;
                     }
                     break;
@@ -68,7 +68,7 @@ export class Achievements extends NoxCommand {
             }
 
             // Disable the buttons if they cannot be used
-            forwardButton.disabled = index > achievements.length - 6;
+            forwardButton.disabled = index > achievements.length - 5;
             backButton.disabled = index < 5;
             startButton.disabled = index === 0;
             endButton.disabled = index >= achievements.length - 5;
@@ -96,10 +96,18 @@ export class Achievements extends NoxCommand {
             })
             .setTitle('Achievements')
             .setColor('DARK_PURPLE')
-            .setThumbnail('https://static.wikia.nocookie.net/smite_gamepedia/images/5/5c/SmiteLogo.png/revision/latest/scale-to-width-down/150?cb=20180503190011')
-            .setFooter({
-                text: `Showing achievements ${index + 1}..${index + 5} out of ${achievements.length}`
-            });
+            .setThumbnail('https://static.wikia.nocookie.net/smite_gamepedia/images/5/5c/SmiteLogo.png/revision/latest/scale-to-width-down/150?cb=20180503190011');
+
+        const maxIndex = index + 5 >= achievements.length
+            ? achievements.length
+            : index + 5;
+        const achievementPaginatedStr = index + 1 === achievements.length
+            ? achievements.length
+            : `${index + 1}..${maxIndex}`;
+            
+        embed.setFooter({
+            text: `Showing achievements ${achievementPaginatedStr} out of ${achievements.length}`
+        });
 
         for (const achievement of achievements.slice(index, index + 5)) {
             const playerIds = await achievement.getCurrentPlayerIds(guild.id);

--- a/src/lib/database/interfaces/ViewsInterfaces.ts
+++ b/src/lib/database/interfaces/ViewsInterfaces.ts
@@ -13,3 +13,17 @@ export interface GodSkinsFullNamesRow {
     skinId: number
 }
 export interface GodSkinsFullNames extends Array<GodSkinsFullNamesRow> { }
+
+export interface PlayerSkinsAmountByGodRow {
+    playerId: number,
+    godId: number,
+    skinsAmount: number
+}
+export interface PlayerSkinsAmountByGod extends Array<PlayerSkinsAmountByGodRow> { }
+
+export interface GodsRoleByPlayersRow {
+    guildId: Snowflake,
+    playerId: number,
+    godsAmount: number
+}
+export interface GodsRoleByPlayers extends Array<GodsRoleByPlayersRow> { }

--- a/src/listeners/Ready.ts
+++ b/src/listeners/Ready.ts
@@ -24,6 +24,7 @@ export class Ready extends  Listener<typeof Events.ClientReady> {
         this.container.logger.info('|_ Loaded ' + this.container.stores.get('achievements').size + ' achievements.');
         this.container.logger.info('|_ Loaded ' + this.container.stores.get('arguments').size + ' arguments.');
         this.container.logger.info('|_ Loaded ' + this.container.stores.get('commands').size + ' commands.');
+        this.container.logger.info('|_ Loaded ' + this.container.stores.get('interaction-handlers').size + ' interaction handlers.');
         this.container.logger.info('|_ Loaded ' + this.container.stores.get('listeners').size + ' listeners.');
         this.container.logger.info('|_ Loaded ' + this.container.stores.get('preconditions').size + ' preconditions.');
         this.container.logger.info('|_ Loaded ' + this.container.stores.get('rewards').size + ' rewards.');


### PR DESCRIPTION
### Features

- 6 New achievements have been added:
  - **One Trick Pony** - Have at least 15 skins of a single god in your team
  - **Hunter Main** - Have at least 15 different Hunter gods in your team
  - **Mage Main** - Have at least 15 different Mage gods in your team
  - **Assassin Main** - Have at least 15 different Assassin gods in your team
  - **Guardian Main** - Have at least 15 different Guardian gods in your team
  - **Warrior Main** - Have at least 15 different Warrior gods in your team

### Bug fixes

- Fixed an issue with the `/achievements` pagination