### PR TITLE
Release/v3.2.0

### DIFF
--- a/src/commands/Smite/CCG/Cooldown.ts
+++ b/src/commands/Smite/CCG/Cooldown.ts
@@ -1,4 +1,5 @@
-import { canPlayerClaimRoll, canPlayerRoll, createPlayerIfNotExists, getTimeLeftBeforeClaim, getTimeLeftBeforeRoll } from '@lib/database/utils/PlayersUtils';
+import { canPlayerClaimRoll, canPlayerRoll, createPlayerIfNotExists, getMaxSkinsPerTeam, getTimeLeftBeforeClaim, getTimeLeftBeforeRoll } from '@lib/database/utils/PlayersUtils';
+import { getSkinsByPlayer } from '@lib/database/utils/SkinsUtils';
 import { PlayerNotLoadedError } from '@lib/structures/errors/PlayerNotLoadedError';
 import { NoxCommand } from '@lib/structures/NoxCommand';
 import { NoxCommandOptions } from '@lib/structures/NoxCommandOptions';
@@ -60,6 +61,10 @@ export class Cooldown extends NoxCommand {
         } else {
             const duration = await getTimeLeftBeforeClaim(player.id);
             cdMsg = `\`${duration.hours()}h ${duration.minutes()}min ${duration.seconds()}s\``;
+        }
+        const skins = await getSkinsByPlayer(player.id);
+        if (skins.length >= getMaxSkinsPerTeam()) {
+            cdMsg += `\n*Cannot claim because team is full.*`;
         }
         embed.addField('Claims', cdMsg, true);
 

--- a/src/commands/Smite/CCG/Give.ts
+++ b/src/commands/Smite/CCG/Give.ts
@@ -16,7 +16,8 @@ import { CommandInteraction } from 'discord.js';
         'targetIsNotABot',
         'playerExists',
         'targetPlayerExists',
-        'targetIsNotBanned'
+        'targetIsNotBanned',
+        'targetPlayerTeamAmountNotMax'
     ]
 })
 export class Give extends NoxCommand {

--- a/src/commands/Smite/CCG/Roll.ts
+++ b/src/commands/Smite/CCG/Roll.ts
@@ -1,4 +1,4 @@
-import { addRoll, canPlayerClaimRoll, getPlayerByUserId, getTimeLeftBeforeClaim, substractAvailableRolls } from '@lib/database/utils/PlayersUtils';
+import { addRoll, canPlayerClaimRoll, getMaxSkinsPerTeam, getPlayerByUserId, getTimeLeftBeforeClaim, substractAvailableRolls } from '@lib/database/utils/PlayersUtils';
 import { connectSkin } from '@lib/database/utils/SkinsUtils';
 import { NoxCommand } from '@lib/structures/NoxCommand';
 import { NoxCommandOptions } from '@lib/structures/NoxCommandOptions';
@@ -94,14 +94,15 @@ export class Roll extends NoxCommand {
             const canClaim = await canPlayerClaimRoll(player.id);
             if (player && player.isBanned) {
                 interaction.followUp({
-                    content: `${user} You have been banned from playing and cannot claim any card.`,
-                    ephemeral: true
+                    content: `${user} You have been banned from playing and cannot claim any card.`
                 });
             } else if (!canClaim) {
                 const duration = await getTimeLeftBeforeClaim(player.id);
                 interaction.followUp({
                     content: `${user} You have to wait \`${duration.hours()} hour(s), ${duration.minutes()} minutes and ${duration.seconds()} seconds\` before claiming a new card again.`
                 });
+            } else if (player.playersSkins.length >= getMaxSkinsPerTeam()) {
+                await interaction.followUp(`${user} You already have a full team and cannot claim any more skins right now.`);
             } else {
                 collector.stop();
 

--- a/src/commands/Smite/CCG/Trade.ts
+++ b/src/commands/Smite/CCG/Trade.ts
@@ -16,10 +16,8 @@ import { CommandInteraction, Message, MessageActionRow, MessageReaction, User } 
         'authorIsNotTarget',
         'targetIsNotABot',
         'playerExists',
-        'playerTeamAmountNotMax',
         'targetPlayerExists',
-        'targetIsNotBanned',
-        'targetPlayerTeamAmountNotMax'
+        'targetIsNotBanned'
     ]
 })
 export class Trade extends NoxCommand {

--- a/src/commands/Smite/CCG/Trade.ts
+++ b/src/commands/Smite/CCG/Trade.ts
@@ -10,14 +10,16 @@ import { ApplicationCommandRegistry, ChatInputCommand } from '@sapphire/framewor
 import { CommandInteraction, Message, MessageActionRow, MessageReaction, User } from 'discord.js';
 
 @ApplyOptions<NoxCommandOptions>({
-    description: 'Start a trade another player.',
+    description: 'Start a trade with another player.',
     preconditions: [
         'guildIsActive',
         'authorIsNotTarget',
         'targetIsNotABot',
         'playerExists',
+        'playerTeamAmountNotMax',
         'targetPlayerExists',
-        'targetIsNotBanned'
+        'targetIsNotBanned',
+        'targetPlayerTeamAmountNotMax'
     ]
 })
 export class Trade extends NoxCommand {

--- a/src/lib/NoxClient.ts
+++ b/src/lib/NoxClient.ts
@@ -33,9 +33,11 @@ declare module '@sapphire/framework' {
         guildIsActive: never,
         playerExists: never,
         playerIsNotBanned: never,
+        playerTeamAmountNotMax: never,
         targetIsNotABot: never,
         targetIsNotBanned: never,
-        targetPlayerExists: never
+        targetPlayerExists: never,
+        targetPlayerTeamAmountNotMax: never
     }
     interface ArgType {
         player: Players

--- a/src/lib/database/utils/PlayersUtils.ts
+++ b/src/lib/database/utils/PlayersUtils.ts
@@ -240,3 +240,7 @@ export async function getTimeLeftBeforeClaim(playerId: number) {
     const timeLeft = claimableDate - now;
     return moment.duration(timeLeft * 1000, 'milliseconds');
 }
+
+export function getMaxSkinsPerTeam() {
+    return parseInt(process.env.MAX_SKINS_PER_TEAM || '');
+}

--- a/src/preconditions/PlayerTeamAmountNotMax.ts
+++ b/src/preconditions/PlayerTeamAmountNotMax.ts
@@ -1,0 +1,45 @@
+import { getMaxSkinsPerTeam, getPlayerByUserId } from '@lib/database/utils/PlayersUtils';
+import { getSkinsByPlayer } from '@lib/database/utils/SkinsUtils';
+import { ApplyOptions } from '@sapphire/decorators';
+import { AsyncPreconditionResult, ChatInputCommand, ContextMenuCommand, Precondition, PreconditionOptions } from '@sapphire/framework';
+import type { CommandInteraction, ContextMenuInteraction } from 'discord.js';
+
+@ApplyOptions<PreconditionOptions>({
+    name: 'playerTeamAmountNotMax'
+})
+export class PlayerTeamAmountNotMax extends Precondition {
+
+    public override async chatInputRun(interaction: CommandInteraction, command: ChatInputCommand, context: Precondition.Context): AsyncPreconditionResult {
+        const { member, guildId } = interaction;
+        const { user } = member;
+
+        const authorPlayer = await getPlayerByUserId(user.id, guildId);
+        const skins = await getSkinsByPlayer(authorPlayer.id);
+
+        const maxSkinsPerTeam = getMaxSkinsPerTeam();
+        if (skins && skins.length >= maxSkinsPerTeam) {
+            return this.error({
+                message: `Player ${authorPlayer} has ${skins.length} and the limit is ${maxSkinsPerTeam}.`
+            });
+        }
+
+        return this.ok();
+    }
+
+    public override async contextMenuRun(interaction: ContextMenuInteraction, command: ContextMenuCommand, context: Precondition.Context) {
+        const { member, guildId } = interaction;
+        const { user } = member;
+
+        const authorPlayer = await getPlayerByUserId(user.id, guildId);
+        const skins = await getSkinsByPlayer(authorPlayer.id);
+
+        const maxSkinsPerTeam = getMaxSkinsPerTeam();
+        if (skins && skins.length >= maxSkinsPerTeam) {
+            return this.error({
+                message: `Player ${authorPlayer} has ${skins.length} and the limit is ${maxSkinsPerTeam}.`
+            });
+        }
+
+        return this.ok();
+    }
+}

--- a/src/preconditions/TargetPlayerTeamAmountNotMax.ts
+++ b/src/preconditions/TargetPlayerTeamAmountNotMax.ts
@@ -1,0 +1,50 @@
+import { getMaxSkinsPerTeam, getPlayerByUserId } from '@lib/database/utils/PlayersUtils';
+import { getSkinsByPlayer } from '@lib/database/utils/SkinsUtils';
+import { ApplyOptions } from '@sapphire/decorators';
+import { AsyncPreconditionResult, ChatInputCommand, ContextMenuCommand, Precondition, PreconditionOptions } from '@sapphire/framework';
+import type { CacheType, CommandInteraction, CommandInteractionOption, ContextMenuInteraction, Snowflake } from 'discord.js';
+
+@ApplyOptions<PreconditionOptions>({
+    name: 'targetPlayerTeamAmountNotMax'
+})
+export class TargetPlayerTeamAmountNotMax extends Precondition {
+
+    public override async chatInputRun(interaction: CommandInteraction, command: ChatInputCommand, context: Precondition.Context): AsyncPreconditionResult {
+        const { guildId } = interaction;
+
+        const isTargetPlayerTeamMax = await this.isTargetPlayerTeamMax(interaction.options.data, guildId);
+        if (isTargetPlayerTeamMax) {
+            return this.error({
+                message: `Target player's team has reached the limit of \`${getMaxSkinsPerTeam()}\` skins per team.`
+            });
+        }
+
+        return this.ok();
+    }
+
+    public override async contextMenuRun(interaction: ContextMenuInteraction, command: ContextMenuCommand, context: Precondition.Context) {
+        const { guildId } = interaction;
+
+        const isTargetPlayerTeamMax = await this.isTargetPlayerTeamMax(interaction.options.data, guildId);
+        if (isTargetPlayerTeamMax) {
+            return this.error({
+                message: `Target player's team has reached the limit of \`${getMaxSkinsPerTeam()}\` skins per team.`
+            });
+        }
+
+        return this.ok();
+    }
+
+    private async isTargetPlayerTeamMax(options: readonly CommandInteractionOption<CacheType>[], guildId: Snowflake): Promise<boolean> {
+        for (let option of options) {
+            if (option.type === 'USER' && !option.user.bot) {
+                const player = await getPlayerByUserId(option.user.id, guildId);
+                const skins = await getSkinsByPlayer(player.id);
+                if (skins && skins.length >= getMaxSkinsPerTeam()) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
### Features

- Players can now only have up to `20` skins in their team.
_This is done to try and prevent skin hoarding.
It forces the players to keep skins they want most only, making seasons last longer for a less stale game, and this should also make trading more relevant._
**_This is subject to change in the future based on your feedback._**